### PR TITLE
Add user, password and index field in elastic-search example

### DIFF
--- a/examples/elastic-search/README.md
+++ b/examples/elastic-search/README.md
@@ -21,4 +21,10 @@ spec:
   params:
     - name: url
       value: <elastic-search url>
+    - name: user
+      value: <user-name>
+    - name: password
+      value: <user-password>
+    - name: index_name
+      value: <index-name>
 ```

--- a/examples/elastic-search/templates/object-elasticsearch.yaml
+++ b/examples/elastic-search/templates/object-elasticsearch.yaml
@@ -7,3 +7,9 @@ spec:
   params:
     - name: url
       value: http://elasticsearch.es-logging.svc.cluster.local:9200 
+    - name: user
+      value: test-elastic
+    - name: password
+      value: test-password
+    - name: index_name
+      value: test-index


### PR DESCRIPTION
Below listed fields tested on minikube environment for elastic-search data store

- [x] url
- [x] user
- [x] password
- [x] index