### PR TITLE
Private/smanpathak/output job bugfixes

### DIFF
--- a/hack/helper/Dockerfile
+++ b/hack/helper/Dockerfile
@@ -3,7 +3,7 @@ LABEL author="smanpathak@platform9.com"
 
 RUN mkdir -p /helper/bin
 WORKDIR /helper
-COPY build/bin/fluentd-operator-helper bin/helper
+COPY build/bin/fluentd-operator-helper-linux-amd64 bin/helper
 RUN chmod +x bin/helper
 
 ENTRYPOINT [ "bin/helper" ]


### PR DESCRIPTION
## Description
Fix for bugs found during e2e testing
1. When output secret is not present, the job should just quit.
2. When output object is already present, the job should skip and not report errors.

## Testing Done
**unit tests**
```
go test ./pkg/...
?   	github.com/platform9/fluentd-operator/pkg/apis	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/apis/logging/v1alpha1	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/client/clientset/versioned	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/client/clientset/versioned/fake	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/client/clientset/versioned/scheme	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/client/clientset/versioned/typed/logging/v1alpha1	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/client/clientset/versioned/typed/logging/v1alpha1/fake	[no test files]
ok  	github.com/platform9/fluentd-operator/pkg/client/tests	(cached)
?   	github.com/platform9/fluentd-operator/pkg/controller	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/controller/fluentbit	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/controller/fluentd	[no test files]
ok  	github.com/platform9/fluentd-operator/pkg/controller/output	(cached)
?   	github.com/platform9/fluentd-operator/pkg/fluentbit	[no test files]
?   	github.com/platform9/fluentd-operator/pkg/fluentbit/internal/syncer	[no test files]
ok  	github.com/platform9/fluentd-operator/pkg/fluentd	(cached)
ok  	github.com/platform9/fluentd-operator/pkg/fluentd/internal/syncer	(cached)
?   	github.com/platform9/fluentd-operator/pkg/options	[no test files]
ok  	github.com/platform9/fluentd-operator/pkg/resources	(cached)
ok  	github.com/platform9/fluentd-operator/pkg/utils	0.029s
```
E2E testing with appbert.