### PR TITLE
Add support for loki in the outputs CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Logging operator provides Kubernetes native log management for developers and de
 * Configure logging using Kubernetes constructs. No need to learn log configurations.
 * Flexibility and Reuse through Kubernetes Custom Resource Definitions.
 * Handles logging service deployment and scaling.
-* Support for popular datastores like ElasticSearch and S3
+* Support for popular datastores like ElasticSearch, S3 and Loki.
 
 #### Concepts ####
-1. ***Output***: An output defines a datastore where logs are to be stored. Currently, the operator supports ElasticSearch and S3 as log stores.
+1. ***Output***: An output defines a datastore where logs are to be stored. Currently, the operator supports ElasticSearch, S3 and Loki as log stores.
 Outputs are defined at cluster scope -- all logs from containers in the cluster get routed to each output.
 
 #### Architecture ####
@@ -23,7 +23,9 @@ Simplest way to install is with bundled deploy script
 ```
 If you are curious, deploy.sh creates prerequesite namespaces and applies yaml manifests under deploy/ directory.
 #### Example Usage With Object Store ####
-This example shows how to forward logs to an object storage. We will be using S3.
+Samples for all the datastores are stored in examples directory.
+
+The below example shows how to forward logs to an object storage. We will be using S3.
 1. Deploy random logger as kubernetes deployment
 ```bash
 kubectl apply -f docs/getting-started/user-guides/random-logger.yaml

--- a/examples/loki/templates/object-loki.yaml
+++ b/examples/loki/templates/object-loki.yaml
@@ -8,10 +8,8 @@ spec:
     - name: url
       value: http://loki.default.svc.cluster.local:3100
     - name: extra_labels
-      value: {"env":"dev"}
+      value: '{"env": "pf9-log"}'
     - name: flush_interval
-      value: 10s
-    - name: flush_at_shutdown
-      value: true
+      value: 1s
     - name: buffer_chunk_limit
-      value: 1m 
+      value: 1m

--- a/examples/loki/templates/object-loki.yaml
+++ b/examples/loki/templates/object-loki.yaml
@@ -1,0 +1,17 @@
+apiVersion: logging.pf9.io/v1alpha1
+kind: Output
+metadata:
+  name: loki-object
+spec:
+  type: loki
+  params:
+    - name: url
+      value: http://loki.default.svc.cluster.local:3100
+    - name: extra_labels
+      value: {"env":"dev"}
+    - name: flush_interval
+      value: 10s
+    - name: flush_at_shutdown
+      value: true
+    - name: buffer_chunk_limit
+      value: 1m 

--- a/pkg/resources/output.go
+++ b/pkg/resources/output.go
@@ -155,6 +155,14 @@ func (o *Output) getLokiParams() (map[string]string, error) {
 		params[name] = v
 	}
 
+	mandatoryParams := []string{"url", "extra_labels"}
+
+	for _, mp := range mandatoryParams {
+		if _, ok := params[mp]; !ok {
+			return map[string]string{}, fmt.Errorf("Mandatory Loki parameter %s is missing", mp)
+		}
+	}
+
 	return params, nil
 }
 

--- a/pkg/resources/output_test.go
+++ b/pkg/resources/output_test.go
@@ -141,6 +141,74 @@ func TestEsRender(t *testing.T) {
 
 }
 
+func TestLokiParams(t *testing.T) {
+	obj := v1alpha1.Output{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "fake",
+		},
+		Spec: v1alpha1.OutputSpec{
+			Type: "loki",
+			Params: []v1alpha1.Param{
+				v1alpha1.Param{
+					Name:  "url",
+					Value: "fake-url",
+				},
+				v1alpha1.Param{
+					Name:  "extra_labels",
+					Value: "fake-labels",
+				},
+			},
+		},
+	}
+
+	o := NewOutput(fake.NewFakeClient(), &obj)
+
+	assert.NotNil(t, o)
+
+	params, err := o.getLokiParams()
+
+	assert.Nil(t, err)
+
+	keys := []string{"url", "extra_labels"}
+
+	for _, k := range keys {
+		_, ok := params[k]
+		assert.True(t, ok)
+	}
+}
+
+func TestLokiRender(t *testing.T) {
+	obj := v1alpha1.Output{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "fake",
+		},
+		Spec: v1alpha1.OutputSpec{
+			Type: "loki",
+			Params: []v1alpha1.Param{
+				v1alpha1.Param{
+					Name:  "url",
+					Value: "fake-url",
+				},
+				v1alpha1.Param{
+					Name:  "extra_labels",
+					Value: "fake-labels",
+				},
+			},
+		},
+	}
+
+	o := NewOutput(fake.NewFakeClient(), &obj)
+
+	assert.NotNil(t, o)
+
+	_, err := o.Render()
+
+	assert.Nil(t, err)
+
+}
+
 func TestS3Params(t *testing.T) {
 	obj := v1alpha1.Output{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
- Add support in output CR for loki datastore. 
- The config created for fluentd needs to be modified to added loki parameters. 
- Add example for loki in templates

## Testing Done
Tested locally on minikube cluster
