### PR TITLE
Add missing libc libraries in alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:latest
 LABEL author="smanpathak@platform9.com"
 
 RUN mkdir -p /fluentd/bin
+RUN apk add --no-cache \
+        libc6-compat
 WORKDIR /fluentd
 COPY build/bin/fluentd-operator-linux-amd64 bin/fluentd-operator
 ADD etc etc


### PR DESCRIPTION
## Description
The fluentd-operator binary generated is dynamically linked that did not run from within the container because the container was missing these libraries:
```
[~/p/s/g/p/fluentd-operator] : docker run platform9/fluentd-operator:latest
standard_init_linux.go:211: exec user process caused "no such file or directory"
```

Installing the libc package fixes this.

## Testing Done
```
[~/p/s/g/p/fluentd-operator] : docker run platform9/fluentd-operator:latest
{"level":"info","ts":1580152719.1207163,"logger":"cmd","caller":"manager/main.go:41","msg":"Go Version: go1.13.3"}
{"level":"info","ts":1580152719.120831,"logger":"cmd","caller":"manager/main.go:42","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1580152719.1208494,"logger":"cmd","caller":"manager/main.go:43","msg":"operator-sdk Version: v0.8.0+git"}
{"level":"error","ts":1580152719.1208656,"logger":"cmd","caller":"manager/main.go:60","msg":"failed to get watch namespace","error":"WATCH_NAMESPACE must be set","stacktrace":"github.com/platform9/fluentd-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/mithil/pf9/src/github.com/platform9/fluentd-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nmain.main\n\t/home/mithil/pf9/src/github.com/platform9/fluentd-operator/cmd/manager/main.go:60\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:203"}
```
