### PR TITLE
Fix logging client serializer

### DIFF
--- a/pkg/client/clientset/versioned/typed/logging/v1alpha1/logging_client.go
+++ b/pkg/client/clientset/versioned/typed/logging/v1alpha1/logging_client.go
@@ -15,7 +15,7 @@ package v1alpha1
 
 import (
 	v1alpha1 "github.com/platform9/fluentd-operator/pkg/apis/logging/v1alpha1"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -65,7 +65,7 @@ func setConfigDefaults(config *rest.Config) error {
 	gv := v1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = serializer.CodecFactory{}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()


### PR DESCRIPTION
## Description
- The logging client is not able to serialize the Output object created
- This change uses kubernetes scheme for serialization

## Testing Done
Tested locally on minikube with k8s v1.17
